### PR TITLE
Allow attribs to work with the Namespace gem...

### DIFF
--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -5,11 +5,11 @@ require "active_support/inflector"
 class Redis
   module Attrs
     def self.redis
-      @redis ||= Redis.new
+      @redis || $redis || Redis.current ||
+        raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
     end
 
     def self.redis=(r)
-      raise ArgumentError, "Redis Attrs: Invalid Redis instance" unless r.is_a?(Redis) || r.is_a?(Redis::Namespace)
       @redis = r
     end
 

--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -9,7 +9,7 @@ class Redis
     end
 
     def self.redis=(r)
-      raise ArgumentError, "Redis Attrs: Invalid Redis instance" unless r.is_a?(Redis)
+      raise ArgumentError, "Redis Attrs: Invalid Redis instance" unless r.is_a?(Redis) || r.is_a?(Redis::Namespace)
       @redis = r
     end
 

--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -6,7 +6,7 @@ class Redis
   module Attrs
     def self.redis
       @redis || $redis || Redis.current ||
-        raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
+        raise(NotConnected, "Redis::Attrs.redis not set to a valid redis connection")
     end
 
     def self.redis=(r)


### PR DESCRIPTION
Changed the setter and getter to work like Redis::Objects because I'd like Attribs to use the Namespaced connection in a similar way to Redis::Objects. In my redis.rb I'm settting them like this:

$redis = Redis::Namespace.new("blah", redis: Redis.new(:host => uri.host, :port => uri.port, :password => uri.password))

Redis::Objects.redis = $redis
Redis::Attrs.redis   = $redis
