### PR TITLE
Pipelining the redis.get of the scalar data types and returning defaults.

### DIFF
--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -44,6 +44,10 @@ class Redis
         Redis::Attrs.redis
       end
 
+      def redis_key
+        redis_key_prefix+":#{id}"
+      end
+
       def redis_attrs_init_all_scalar
         redis.pipelined do
           self.class.redis_attrs.each do |ra|

--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -56,7 +56,7 @@ class Redis
         string:  Redis::Attrs::String,
         boolean: Redis::Attrs::Boolean,
         date:    Redis::Attrs::Date,
-        time:    Redis::Attrs::Time,
+        time:    Redis::Attrs::RaTime,
         integer: Redis::Attrs::Integer,
         float:   Redis::Attrs::Float,
 
@@ -82,7 +82,7 @@ class Redis
     autoload :String,  'redis-attrs/string'
     autoload :Boolean, 'redis-attrs/boolean'
     autoload :Date,    'redis-attrs/date'
-    autoload :Time,    'redis-attrs/time'
+    autoload :RaTime,    'redis-attrs/ra_time'
     autoload :Integer, 'redis-attrs/integer'
     autoload :Float,   'redis-attrs/float'
     autoload :Complex, 'redis-attrs/complex'

--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -45,7 +45,7 @@ class Redis
       end
 
       def redis_key
-        redis_key_prefix+":#{id}"
+        self.class.redis_key_prefix+":#{id}"
       end
 
       def redis_attrs_init_all_scalar

--- a/lib/redis-attrs.rb
+++ b/lib/redis-attrs.rb
@@ -44,6 +44,18 @@ class Redis
         Redis::Attrs.redis
       end
 
+      def redis_attrs_init_all_scalar
+        redis.pipelined do
+          self.class.redis_attrs.each do |ra|
+            if ra.is_a?(Scalar) && ra.options[:default]
+              redis.set(ra.redis_key(id), ra.options[:default])
+            else
+              redis.del ra.redis_key(id)
+            end
+          end
+        end
+      end
+
       def redis_attrs_get_all_scalar
         redis_ary = redis.pipelined do
           self.class.redis_attrs.each {|ra| redis.get ra.redis_key(id) if ra.is_a?(Scalar) }

--- a/lib/redis-attrs/ra_time.rb
+++ b/lib/redis-attrs/ra_time.rb
@@ -1,6 +1,6 @@
 class Redis
   module Attrs
-    class Time < Scalar
+    class RaTime < Scalar
       def deserialize(value)
         value.nil? ? nil : ::Time.parse(value)
       end

--- a/lib/redis-attrs/scalar.rb
+++ b/lib/redis-attrs/scalar.rb
@@ -11,7 +11,11 @@ class Redis
         # Define the getter
         klass.send(:define_method, name) do
           value = redis.get attr.redis_key(id)
-          value.nil? ? nil : attr.deserialize(value)
+          if value.nil?
+            attr.options && attr.options[:default] ? attr.options[:default] : nil
+          else
+             attr.deserialize(value)
+          end
         end
 
         # Define the setter

--- a/spec/redis_attrs_spec.rb
+++ b/spec/redis_attrs_spec.rb
@@ -45,9 +45,9 @@ describe Redis::Attrs do
     end
 
     it "gives instances of the class unique redis keys" do
-      expect(Film.redis_key).to eq("film:1")
+      expect(film.redis_key).to eq("film:1")
     end
-    
+
   end
 
   describe ".redis_attrs" do

--- a/spec/redis_attrs_spec.rb
+++ b/spec/redis_attrs_spec.rb
@@ -43,6 +43,11 @@ describe Redis::Attrs do
       expect(Film.redis).to be_a(Redis)
       expect(Film.redis).to equal(film.redis)
     end
+
+    it "gives instances of the class unique redis keys" do
+      expect(Film.redis_key).to eq("film:1")
+    end
+    
   end
 
   describe ".redis_attrs" do
@@ -53,7 +58,7 @@ describe Redis::Attrs do
       end
     end
 
-    context "with no paremeters" do
+    context "with no parameters" do
       let(:attrs) { [:title, :released_on, :length, :created_at, :featured, :rating, :stars, :scenes]}
       let(:types) { [:string, :date, :integer, :time, :boolean, :float, :integer, :float] }
 

--- a/spec/redis_attrs_spec.rb
+++ b/spec/redis_attrs_spec.rb
@@ -179,4 +179,18 @@ describe Redis::Attrs do
       film.genres.members.sort.should == ["action", "drama", "film noir", "western"]
     end
   end
+
+  describe "bugs" do
+    it "should not interfere with the ruby Time class" do
+      class Film
+        def year_test
+          Time.now.year
+        end
+      end
+
+      expect(film.year_test).to eq(Time.now.year)
+    end
+  end
+
+
 end


### PR DESCRIPTION
Dear Ernesto,

For performance reasons I need to pipeline the gets of all my values which happen to all be scalar. Since the complex data types present more issues I decided to wait and see what you thought about the idea, and my implementation before continuing. As you can see, I also hacked in default handling. This is a convenience for me so that I don't have to write a bunch of defensive code for nil checking. My application doesn't expect floats and integers to be nil. This small mod means I don't have to check them. Overall, I think you've done a great job with this gem and I'm just tweaking it for my particular case. If you like my changes and would like to include them, I'd be happy to write the readme changes as well.
